### PR TITLE
Attiny sketch improvements

### DIFF
--- a/DMGC-IPS-01/DMGC-IPS-01_ATTINY85.ino
+++ b/DMGC-IPS-01/DMGC-IPS-01_ATTINY85.ino
@@ -4,6 +4,9 @@
 
 #include <Adafruit_NeoPixel.h>
 #include <EEPROM.h>
+#include <avr/interrupt.h>
+#include <avr/power.h>
+#include <avr/sleep.h>
 
 // Which pin on the Arduino is connected to the NeoPixels?
 #define OUT           PCINT4 // PB4
@@ -28,20 +31,36 @@ Adafruit_NeoPixel pixels(NUMPIXELS, OUT, NEO_GRB + NEO_KHZ800);
 
 volatile uint8_t brightness;
 volatile uint8_t color_type;
-const uint8_t    COLOR_QTY  = 9;
+const uint8_t    COLOR_QTY  = 14;
+const uint8_t    RAINBOW_START_IDX = 10;
 const uint8_t    DEBOUNCE_DELAY = 50;
+const uint8_t    LOOP_DELAY = 10;
 const uint8_t    BRIGHTNESS_INC = 5;
 const uint8_t    MIN_BRIGHTNESS = 5;
 const uint8_t    MAX_BRIGHTNESS = 50;
 
 volatile uint8_t brightness_change_flag = 0;
 
-// cycles through different colors:    red  org  ylw  grn  cyan blue purp wht  off
-volatile uint8_t red[COLOR_QTY]   =  { 255, 255, 255, 0,   0,   0,   255, 255, 0};
-volatile uint8_t green[COLOR_QTY] =  { 0,   100, 200, 255, 255, 0,   0,   255, 0};
-volatile uint8_t blue[COLOR_QTY]  =  { 0,   0,   0,   0,   255, 255, 255, 255, 0};
+// cycles through different colors:  red  org  ylw  grn  cyan blue purp pink wht  off rainbow rainbow_slow rainbow_med rainbow_fast
+const uint8_t red[COLOR_QTY]     = { 255, 255, 255, 0,   0,   0,   255, 242, 255, 0,  0,      0,           0,          0};
+const uint8_t green[COLOR_QTY]   = { 0,   100, 200, 255, 255, 0,   0,   90,  255, 0,  0,      0,           0,          0};
+const uint8_t blue[COLOR_QTY]    = { 0,   0,   0,   0,   255, 255, 255, 255, 255, 0,  0,      0,           0,          0};
+// Rainbow animation speed
+const uint8_t rainbow[COLOR_QTY] = { 0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  0,      37,          76,         151};
+
+const uint8_t RAINBOW_SAT    = 255; // Rainbow saturation (S in HSV)
+const uint8_t RAINBOW_VAL    = 255; // Rainbow value (V in HSV)
+const uint16_t RAINBOW_START = 10240; // Chosen a bit arbitrarily
+volatile uint16_t rainbow_current = RAINBOW_START;
 
 void setup() {
+
+  // Disable the ADC to save a slight amount of power
+  ADCSRA = 0;
+  power_adc_disable();
+
+  // Set SLEEP_MODE_PWR_DOWN, the lowest power sleep mode
+  set_sleep_mode(SLEEP_MODE_PWR_DOWN);
 
   pixels.begin();
 
@@ -51,14 +70,23 @@ void setup() {
   // Check if EPROM data was corrupted, set brightness to max or min values
   if (brightness>MAX_BRIGHTNESS){
     brightness=MAX_BRIGHTNESS;
+    EEPROM.put(0,brightness);
   }
   if (brightness<MIN_BRIGHTNESS){
     brightness=MIN_BRIGHTNESS;
+    EEPROM.put(0,brightness);
   }
-  
+
+  // Set color_type back to 0 if it's an invalid value
+  if (color_type>COLOR_QTY-1){
+    color_type=0;
+    EEPROM.put(1,color_type);
+  }
+
   pixels.setBrightness(brightness);
 
   // Inputs *MUST NOT* use ATTINY's pull-ups. These will rely on the GBC CPU's internal pull-ups to 3.3V. The ATTINY is powered by 5V!!
+  // When developing without the CPU board plugged in, change these to INPUT_PULLUP. Change them back to INPUT before reassembly!
   pinMode(pushbtn, INPUT);
   pinMode(leftbtn, INPUT);
   pinMode(rightbtn, INPUT);
@@ -71,10 +99,10 @@ void setup() {
       pixels.show();
       delay(1100);
 
-      int y=6;
+      const int y=6;
       int k=0;
 
-      uint8_t introarray[24] = {8,8,8,8,8,8,8,2,2,0,0,6,6,3,3,5,5,5,5,5,5,5,5,5};
+      const uint8_t introarray[24] = {9,9,9,9,9,9,9,2,2,0,0,6,6,3,3,5,5,5,5,5,5,5,5,5};
 
       // Loop through values in introarray. Delays were timed experimentally.
       for(int j=0; j<16; j++){
@@ -110,7 +138,9 @@ void setup() {
       }
       delay(2000);
   }else{
-    while(1){};
+    while(1){
+      sleep(false); // Sleep forever!
+    };
   }
 //  while(!digitalRead(pushbtn)){
 //    delay(10);
@@ -118,9 +148,6 @@ void setup() {
 }
 
 void loop() {
-  // Update LED outputs
-  outputLED(color_type);
-
   // If nav switch is pressed
   if(digitalRead(pushbtn)==LOW){
     // Pause the program to debounce the switch, check to make sure it's still pressed
@@ -145,7 +172,7 @@ void loop() {
             outputLED(color_type);
           }
         }
-        
+
         if(digitalRead(leftbtn)==LOW){
           delay(DEBOUNCE_DELAY);
           if(digitalRead(leftbtn)==LOW){
@@ -164,25 +191,71 @@ void loop() {
         }
         delay(DEBOUNCE_DELAY);
       }
-      
+
       if(brightness_change_flag==0){
         if(color_type==COLOR_QTY-1){
           color_type=0;
+          rainbow_current=RAINBOW_START;
         }else{
           color_type = color_type+1;
         }
       }
       // Save brightness and color setting to EPROM
-      EEPROM.put(0,brightness);
-      EEPROM.put(1,color_type);
+      EEPROM.update(0,brightness);
+      EEPROM.update(1,color_type);
       brightness_change_flag = 0;
       }
+    }
+
+    // Update LED outputs
+    outputLED(color_type);
+
+    // Sleep if showing a static color or static rainbow
+    if (color_type <= RAINBOW_START_IDX) {
+      sleep(true);
+    } else {
+      // Delay just a bit so we're not refreshing the LEDs so fast
+      delay(LOOP_DELAY);
     }
   }
 
 void outputLED(uint8_t x){
-  for(int i=0; i<NUMPIXELS; i++) { // For each pixel...
-    pixels.setPixelColor(i, pixels.Color(red[x],green[x],blue[x]));
-    pixels.show();   // Send the updated pixel colors to the hardware.
-  }  
+  // Rainbow logic; similar to NeoPixel library's, except with first two pixels swapped
+  if (x >= RAINBOW_START_IDX) {
+    for (uint16_t i=0; i<NUMPIXELS; i++) { // For each pixel...
+      uint16_t j = i; // Swap left and up
+      if (j == u) {
+        j = l;
+      } else if (j == l) {
+        j = u;
+      }
+      uint16_t hue = rainbow_current + (i * 65536) / NUMPIXELS;
+      uint32_t color = pixels.ColorHSV(hue, RAINBOW_SAT, RAINBOW_VAL);
+      pixels.setPixelColor(j, pixels.gamma32(color));
+    }
+    rainbow_current += rainbow[x];
+  } else {
+    for(int i=0; i<NUMPIXELS; i++) { // For each pixel..
+      pixels.setPixelColor(i, pixels.Color(red[x],green[x],blue[x]));
+    }
+  }
+  pixels.show();   // Send the updated pixel colors to the hardware.
+}
+
+// ISR - called when push is pushed during sleep to wake up
+ISR(PCINT0_vect) {
+  GIMSK &= ~0b00100000;  // Turn off pin change interrupts
+  sleep_disable();
+}
+
+// Sleeps to save ~25 mW
+void sleep(bool can_wake) {
+  sleep_enable();
+  if (can_wake) { // Enable interrupts so we can wake up
+    noInterrupts();
+    GIMSK |= 0b00100000;  // Turn on pin change interrupts
+    PCMSK |= 1 << pushbtn; // For pin 3 - pushbtn
+    interrupts();
+  }
+  sleep_cpu();
 }


### PR DESCRIPTION
1. Put the Attiny85 into power down sleep mode when not doing anything, saving theoretically ~25 mW (from my experiments, measuring power consumption via the DC jack, the actual savings appears to actually be over 40 mW!)
2. Add pink after purple - it looks great with many builds.
3. Adds a rainbow cycle animation. This contains 4 more color modes containing various speeds of rainbow cycle animations. Static rainbow, slow, medium, and fast.
4. Use EEPROM.update instead of EEPROM.put to save some write cycles, in case anyone was concerned about the 100k write cycles on their Attiny lol. Using update instead of put doesn't write the brightness bit when changing color and vice versa.

How to test power consumption: set screen brightness and sound to the lowest. Toggle LEDs to "off" setting. Measure power consumption to get the "sleeping" value. Now push the button (don't release) to get the "active" value.